### PR TITLE
Retry Logging API requests when encountering 500 errors

### DIFF
--- a/sources/Google.Solutions.LicenseTracker/CommandLineOptions.cs
+++ b/sources/Google.Solutions.LicenseTracker/CommandLineOptions.cs
@@ -116,7 +116,7 @@ namespace Google.Solutions.LicenseTracker
                 },
                 {
                     "analysis-window=",
-                    $"Size of analysis window (Default: {DefaultAnalysisWindowSizeInDays} days",
+                    $"Size of analysis window (in days, default: {DefaultAnalysisWindowSizeInDays})",
                     v => commandLine.AnalysisWindowSizeInDays = uint.Parse(v)
                 },
                 {

--- a/sources/Google.Solutions.LicenseTracker/Util/ExecuteAsStreamExtensions.cs
+++ b/sources/Google.Solutions.LicenseTracker/Util/ExecuteAsStreamExtensions.cs
@@ -74,7 +74,7 @@ namespace Google.Solutions.LicenseTracker.Util
                         .ExecuteAsStreamOrThrowAsync(cancellationToken)
                         .ConfigureAwait(false); ;
                 }
-                catch (GoogleApiException e) when (e.Error != null && e.Error.Code == 429)
+                catch (GoogleApiException e) when (e.Error != null && (e.Error.Code == 429 || e.Error.Code == 500))
                 {
                     // Too many requests.
                     if (retries < backOff.MaxNumOfRetries)


### PR DESCRIPTION
The Logging API occasionally returns 500/internal server errors. Modify adapter to retry requests.

Also, fix a typo in the command line options.