### PR TITLE
b/280007361 Interpret automaticRestart event as start event

### DIFF
--- a/sources/Google.Solutions.LicenseTracker/Data/Events/System/AutomaticRestartEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/System/AutomaticRestartEvent.cs
@@ -24,7 +24,7 @@ using System.Diagnostics;
 
 namespace Google.Solutions.LicenseTracker.Data.Events.System
 {
-    public class AutomaticRestartEvent : SystemEventBase
+    public class AutomaticRestartEvent : SystemEventBase, IInstanceStateChangeEvent
     {
         public const string Method = "compute.instances.automaticRestart";
 
@@ -38,5 +38,13 @@ namespace Google.Solutions.LicenseTracker.Data.Events.System
             return record.IsSystemEvent &&
                 record.ProtoPayload?.MethodName == Method;
         }
+
+        //---------------------------------------------------------------------
+        // IInstanceStateChangeEvent.
+        //---------------------------------------------------------------------
+
+        public bool IsStartingInstance => true;
+
+        public bool IsTerminatingInstance => false;
     }
 }


### PR DESCRIPTION
The compute.instances.automaticRestart was previously not treated as a start event, which could result in under-reporting of some placements.