### PR TITLE
b/281617447 Fix handling of synthetic placement events

### DIFF
--- a/sources/Google.Solutions.LicenseTracker.Test/Data/History/TestInstanceSetHistoryBuilder.cs
+++ b/sources/Google.Solutions.LicenseTracker.Test/Data/History/TestInstanceSetHistoryBuilder.cs
@@ -157,7 +157,7 @@ namespace Google.Solutions.LicenseTracker.Test.Data.History
                         { "instance_id", "123" }
                     }
                 },
-                Timestamp = new DateTime(2019, 12, 31)
+                Timestamp = new DateTime(2019, 12, 31, 0, 0, 0, DateTimeKind.Utc)
             }));
 
             var set = b.Build();

--- a/sources/Google.Solutions.LicenseTracker/Data/History/Placement.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/History/Placement.cs
@@ -72,7 +72,6 @@ namespace Google.Solutions.LicenseTracker.Data.History
             DateTime to)
         {
             Debug.Assert(from <= to);
-            Debug.Assert(tenancy != Tenancies.Unknown);
             Debug.Assert(!tenancy.IsFlagCombination());
             Debug.Assert(from.Kind == DateTimeKind.Utc);
             Debug.Assert(to.Kind == DateTimeKind.Utc);

--- a/sources/Google.Solutions.LicenseTracker/Data/History/PlacementHistoryBuilder.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/History/PlacementHistoryBuilder.cs
@@ -246,6 +246,26 @@ namespace Google.Solutions.LicenseTracker.Data.History
                         firstPlacement.To)
                 };
             }
+            else if (lastEventDate != DateTime.MaxValue &&
+                this.lastStoppedOn != null &&
+                (!this.placements.Any() || this.lastStoppedOn < this.placements.First()?.From))
+            {
+                //
+                // We received an event indicating that the instance was
+                // stopped, but we did not see a corresponding start
+                // event -- so the instance must have been started
+                // before the analysis window.
+                //
+                sanitizedPlacements = new[]
+                {
+                    new Placement(
+                        Tenancies.Unknown,
+                        null,
+                        null,
+                        reportStartDate,
+                        lastStoppedOn.Value)
+                };
+            }
 
             Debug.Assert(sanitizedPlacements.All(p => p.From != p.To));
 


### PR DESCRIPTION
* Update view so that it ignores redundant start-placements events
* Extend history builder so that it emits synthetic end-placements events
  when an instance was stopped duting the analysis window, but the 
  corresponding start-event happened outside the analysis window.