### PR TITLE
b/281762203 Handle truncated machine types in logs

### DIFF
--- a/sources/Google.Solutions.LicenseTracker/Data/Events/Config/SetMachineTypeEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/Config/SetMachineTypeEvent.cs
@@ -40,6 +40,12 @@ namespace Google.Solutions.LicenseTracker.Data.Events.Config
             if (logRecord.ProtoPayload?.Request?.Value<string>("machineType") is var machineType &&
                 !string.IsNullOrEmpty(machineType))
             {
+                if (machineType.StartsWith("zones/"))
+                {
+                    // b/281762203.
+                    machineType = "projects/-/" + machineType;
+                }
+
                 this.MachineType = MachineTypeLocator.FromString(machineType);
             }
         }

--- a/sources/Google.Solutions.LicenseTracker/Data/Events/Config/UpdateInstanceEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/Config/UpdateInstanceEvent.cs
@@ -48,6 +48,12 @@ namespace Google.Solutions.LicenseTracker.Data.Events.Config
                 if (request?.Value<string>("machineType") is var machineType &&
                     !string.IsNullOrEmpty(machineType))
                 {
+                    if (machineType.StartsWith("zones/"))
+                    {
+                        // b/281762203.
+                        machineType = "projects/-/" + machineType;
+                    }
+
                     this.MachineType = MachineTypeLocator.FromString(machineType);
                 }
 

--- a/sources/Google.Solutions.LicenseTracker/Data/Events/Lifecycle/InsertInstanceEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/Lifecycle/InsertInstanceEvent.cs
@@ -83,6 +83,12 @@ namespace Google.Solutions.LicenseTracker.Data.Events.Lifecycle
                 if (request.Value<string>("machineType") is var machineType &&
                     !string.IsNullOrEmpty(machineType))
                 {
+                    if (machineType.StartsWith("zones/"))
+                    {
+                        // b/281762203.
+                        machineType = "projects/-/" + machineType;
+                    }
+
                     this.MachineType = MachineTypeLocator.FromString(machineType);
                 }
 


### PR DESCRIPTION
Some log records contain machine types that lack the "project/<project>/" prefix.