### PR TITLE
b/352186158 Ignore order of label attributes

### DIFF
--- a/sources/Google.Solutions.LicenseTracker.Test/Data/Events/Config/TestSetLabelsEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker.Test/Data/Events/Config/TestSetLabelsEvent.cs
@@ -52,8 +52,8 @@ namespace Google.Solutions.LicenseTracker.Test.Data.Events.Config
                           'value': 'value-1'
                         },
                         {
-                          'key': 'label-2',
-                          'value': 'value-2'
+                          'value': 'value-2',
+                          'key': 'label-2'
                         },
                         {
                           'key': 'label-2',

--- a/sources/Google.Solutions.LicenseTracker.Test/Data/Events/Config/TestUpdateInstanceEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker.Test/Data/Events/Config/TestUpdateInstanceEvent.cs
@@ -93,8 +93,8 @@ namespace Google.Solutions.LicenseTracker.Test.Data.Events.Config
                       },
                       'labels': [
                         {
-                          'key': 'label-1',
-                          'value': 'value-1'
+                          'value': 'value-1',
+                          'key': 'label-1'
                         },
                         {
                           'key': 'label-2',

--- a/sources/Google.Solutions.LicenseTracker.Test/Data/Events/Lifecycle/TestInsertInstanceEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker.Test/Data/Events/Lifecycle/TestInsertInstanceEvent.cs
@@ -266,8 +266,8 @@ namespace Google.Solutions.LicenseTracker.Test.Data.Events.Lifecycle
                    },
                   'labels': [
                     {
-                      'key': 'label-1',
-                      'value': 'value-1'
+                      'value': 'value-1',
+                      'key': 'label-1'
                     },
                     {
                       'key': 'label-1',

--- a/sources/Google.Solutions.LicenseTracker/Data/Events/Config/SetLabelsEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/Config/SetLabelsEvent.cs
@@ -44,8 +44,8 @@ namespace Google.Solutions.LicenseTracker.Data.Events.Config
                 this.Labels = labels
                     .OfType<JObject>()
                     .Select(item => new {
-                        Key = (string?)item.PropertyValues().ElementAtOrDefault(0),
-                        Value = (string?)item.PropertyValues().ElementAtOrDefault(1)
+                        Key = (string?)item.Value<string?>("key"),
+                        Value = (string?)item.Value<string?>("value")
                     })
                     .Where(item => item.Key != null && item.Value != null)
                     .DistinctBy(item => item.Key)

--- a/sources/Google.Solutions.LicenseTracker/Data/Events/Config/UpdateInstanceEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/Config/UpdateInstanceEvent.cs
@@ -71,8 +71,8 @@ namespace Google.Solutions.LicenseTracker.Data.Events.Config
                     this.Labels = labels
                         .OfType<JObject>()
                         .Select(item => new {
-                            Key = (string?)item.PropertyValues().ElementAtOrDefault(0),
-                            Value = (string?)item.PropertyValues().ElementAtOrDefault(1)
+                            Key = (string?)item.Value<string?>("key"),
+                            Value = (string?)item.Value<string?>("value")
                         })
                         .Where(item => item.Key != null && item.Value != null)
                         .DistinctBy(item => item.Key)

--- a/sources/Google.Solutions.LicenseTracker/Data/Events/Lifecycle/InsertInstanceEvent.cs
+++ b/sources/Google.Solutions.LicenseTracker/Data/Events/Lifecycle/InsertInstanceEvent.cs
@@ -107,8 +107,8 @@ namespace Google.Solutions.LicenseTracker.Data.Events.Lifecycle
                     this.Labels = labels
                         .OfType<JObject>()
                         .Select(item => new {
-                            Key = (string?)item.PropertyValues().ElementAtOrDefault(0),
-                            Value = (string?)item.PropertyValues().ElementAtOrDefault(1)
+                            Key = (string?)item.Value<string?>("key"),
+                            Value = (string?)item.Value<string?>("value")
                         })
                         .Where(item => item.Key != null && item.Value != null)
                         .DistinctBy(item => item.Key)


### PR DESCRIPTION
While attributes are usually in the order 'key, value', they can sometimes be reversed. Fix parsing logic to not rely on order.